### PR TITLE
Update Footer Troublehooting Link

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -64,7 +64,7 @@
         <div>
           <a href="https://discord.gg/premid">Discord</a>
           <a
-            href="https://wiki.premid.app/"
+            href="https://docs.premid.app/troubleshooting/"
             v-text="$t(`footer.help.troubleshooting`)"
           />
           <a


### PR DESCRIPTION
Changed the href to point to the troubleshooting page instead of the home page of the documentation.