### PR TITLE
Search presences using alternative names

### DIFF
--- a/src/components/StoreCard.vue
+++ b/src/components/StoreCard.vue
@@ -157,7 +157,6 @@
 <script>
 	import PresenceMixin from "./mixins/Presence";
 	import tinycolor from "tinycolor2";
-	import axios from "axios";
 
 	export default {
 		name: "StoreCard",

--- a/src/pages/store/index.vue
+++ b/src/pages/store/index.vue
@@ -330,9 +330,18 @@
 								: false;
 						else if (
 							!this.showAdded &&
-							presence.service
-								?.toLowerCase()
-								.includes(this.presenceSearch.toLowerCase())
+							(
+								presence.service
+									?.toLowerCase()
+									.includes(this.presenceSearch.toLowerCase()) ||
+								(
+									Array.isArray(presence.altnames) &&
+									presence.altnames.filter(altname =>
+										altname.toLowerCase()
+										.includes(this.presenceSearch.toLowerCase())
+									).length > 0
+								)
+							)
 						)
 							return !this.addedPresences.includes(presence.service);
 						else
@@ -342,10 +351,15 @@
 									.includes(this.presenceSearch.toLowerCase()) ||
 								(Array.isArray(presence.tags) &&
 									presence.tags.filter(tag =>
-										tag
-											.toLowerCase()
-											.includes(this.presenceSearch.toLowerCase())
-									).length > 0)
+										tag.toLowerCase()
+										.includes(this.presenceSearch.toLowerCase())
+								).length > 0) ||
+								(Array.isArray(presence.altnames) &&
+									presence.altnames.filter(altname =>
+										altname.toLowerCase()
+										.includes(this.presenceSearch.toLowerCase())
+									).length > 0
+								)
 							);
 					})
 					.filter(presence =>


### PR DESCRIPTION
Presences can have a optional field, `altnames` of type `Array<string>`; this field is used to store alternative names of the presence, for example for the presence Amazon this field could have the values "aws", "s3", etc.

This pull request enables the search of presences using the "altnames".