### PR TITLE
Alternative service names #2

### DIFF
--- a/src/components/StoreCard.vue
+++ b/src/components/StoreCard.vue
@@ -20,7 +20,7 @@
 							:to="`/store/presences/${encodeURIComponent(presenceLinkName)}`"
 						>
 							{{
-								altnamesSearch && presence.altnames
+								altnamesSearch && !presence.service.toLowerCase().includes(altnamesSearch) && presence.altnames
 								? presence.altnames
 									.find(a =>
 										a.toLowerCase().includes(altnamesSearch)

--- a/src/components/StoreCard.vue
+++ b/src/components/StoreCard.vue
@@ -19,7 +19,15 @@
 							:key="presenceLinkName"
 							:to="`/store/presences/${encodeURIComponent(presenceLinkName)}`"
 						>
-							{{ presence.service }}
+							{{
+								altnamesSearch && presence.altnames
+								? presence.altnames
+									.find(a =>
+										a.toLowerCase().includes(altnamesSearch)
+									) || presence.service
+								:
+								presence.service
+							}}
 							<span
 								v-if="partner"
 								v-tippy="{
@@ -153,7 +161,7 @@
 	export default {
 		name: "StoreCard",
 		mixins: [PresenceMixin],
-		props: ["presence", "submit", "nsfw", "hot", "partner"],
+		props: ["presence", "submit", "nsfw", "hot", "partner", "altnamesSearch"],
 		data() {
 			return {
 				cardHovered: false,

--- a/src/pages/store/index.vue
+++ b/src/pages/store/index.vue
@@ -203,6 +203,7 @@
 						v-for="presence in paginatedData"
 						:key="presence.metadata.service"
 						:presence="presence.metadata"
+						:altnamesSearch="presenceSearch"
 						:hot="
 							hotPresences.filter(
 								p => p.metadata.service === presence.metadata.service


### PR DESCRIPTION
✔️ Use the matched alternative name as the service name.
🐛 (cannot reproduce) presence showing up even it "show added" is disabled. 

If a alternative name `presence.altname` and main one `presence.service`matches the main one is used.

### Screenshot proofs:

Data of the Pokémon presence
![image](https://user-images.githubusercontent.com/22194879/92512166-adf1f280-f20e-11ea-8fdf-c85ea569ab1c.png)

- Conflict between `Pokémon` (main name) and `Pokemon` (altname[0])
![proof 1](https://user-images.githubusercontent.com/22194879/92511944-56ec1d80-f20e-11ea-8bec-d2ad977f72ac.png)

- Pokémon altname[1]
![proof 2](https://user-images.githubusercontent.com/22194879/92511891-4176f380-f20e-11ea-8ecf-3365c5d054b5.png)
![image](https://user-images.githubusercontent.com/22194879/92512291-ded22780-f20e-11ea-9832-86baaa1bc18f.png)

- Presence hidden when `Show added Presences` is not checked and added to the extension. Expected behaviour.
![proof 3](https://user-images.githubusercontent.com/22194879/92512866-be569d00-f20f-11ea-9616-1d85b296e482.png)

- Presence shown when `Show added Presences` is checked
![proof 4](https://user-images.githubusercontent.com/22194879/92513132-1ab9bc80-f210-11ea-9847-ffc9999e1abe.png)
