### PR TITLE
build(deps): ➖ Remove unneeded dependancy

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -23,7 +23,6 @@ module.exports = {
 		{ src: "~/plugins/Modal.js", mode: "client" }
 	],
 	modules: [
-		"@nuxt/components",
 		[
 			"nuxt-lazy-load",
 			{

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
 		"pretty": "prettier --write **/*.vue **/*.js **/*.json **/*.scss"
 	},
 	"dependencies": {
-		"@nuxt/components": "1.1.0",
 		"@nuxt/typescript-runtime": "2.0.0",
 		"@nuxtjs/auth": "4.9.1",
 		"@nuxtjs/axios": "5.12.2",


### PR DESCRIPTION
Since version 2.13, nuxt itself includes the @nuxt/components dependency.
https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-components