### PR TITLE
ci: add build CI and fix dependabot merge

### DIFF
--- a/.github/workflows/CD Docker.yml
+++ b/.github/workflows/CD Docker.yml
@@ -1,11 +1,11 @@
 name: CD Docker
 on:
   workflow_run:
-    workflows: ["CI Dependencies"]
+    workflows: ["CI"]
     branches:
       - stable
       - main
-    types: 
+    types:
       - completed
 jobs:
   docker:

--- a/.github/workflows/CD Docker.yml
+++ b/.github/workflows/CD Docker.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'PreMiD'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,22 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Install dependencies and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Node v16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,5 +1,5 @@
 name: CI Dependencies
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   automerge:

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,9 +1,17 @@
-name: CI Dependencies
-on: pull_request
+name: Merge dependabot PRs
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches:
+      - stable
+      - main
+    types:
+      - completed
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
This PR adds a new CI that simply runs yarn build on PRs and pushes, fixes the dependabot merge action to prevent it from running on push and prevents the CD Docker workflow from running on forks (which causes the workflow to fail)