### PR TITLE
:pushpin: Keep sass-loader @ 10.x

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,5 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 15
+    ignore:
+      - dependency-name: "sassloader"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,5 +13,7 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 15
+    #Should be removed/updated when nuxt + vue support webpack 5
     ignore:
-      - dependency-name: "sassloader"
+      - dependency-name: "sass-loader"
+        version: "^11"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
 		"prettier": "2.4.1",
 		"rimraf": "3.0.2",
 		"sass": "^1.43.4",
-		"sass-loader": "^12.3.0"
+		"sass-loader": "^10.2.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6856,13 +6856,16 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-loader@^12.3.0:
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-12.3.0.tgz#93278981c189c36a58cbfc37d4b9cef0cdc02871"
-  integrity sha512-6l9qwhdOb7qSrtOu96QQ81LVl8v6Dp9j1w3akOm0aWHyrTYtagDt5+kS32N4yq4hHk3M+rdqoRMH+lIdqvW6HA==
+sass-loader@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.2.0.tgz#3d64c1590f911013b3fa48a0b22a83d5e1494716"
+  integrity sha512-kUceLzC1gIHz0zNJPpqRsJyisWatGYNFRmv2CKZK2/ngMJgLqxTbXwe/hJ85luyvZkgqU3VlJ33UVF2T/0g6mw==
   dependencies:
     klona "^2.0.4"
+    loader-utils "^2.0.0"
     neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    semver "^7.3.2"
 
 sass@^1.43.4:
   version "1.43.4"


### PR DESCRIPTION
Will prevent dependabot from updating above 11 which requires webpack 5

Check if the ignore version is correct; It cannot pass 11