### PR TITLE
Preserve user profile privacy

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -440,7 +440,7 @@
 
 				presence.profile = {
 					name: this.users[index].user.name,
-					discriminator: this.users[index].user.tag,
+					discriminator: [,,,,].fill().map(() => Math.floor(Math.random() * 10)).join(""),
 					flags: this.users[index].user.flags || [],
 					avatar: this.users[index].user.avatar
 				};

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -440,7 +440,7 @@
 
 				presence.profile = {
 					name: this.users[index].user.name,
-					discriminator: [,,,,].fill().map(() => Math.floor(Math.random() * 10)).join(""),
+					discriminator: Array(4).fill().map(() => Math.floor(Math.random() * 10)).join(""),
 					flags: this.users[index].user.flags || [],
 					avatar: this.users[index].user.avatar
 				};


### PR DESCRIPTION
I've been added by random people many times before, who just saw me show up on the website thanks to being in the PreMiD Discord, which I find weird and irritating, so at least randomize the user discriminator so you can't be added that easily, while still looking like a real user.