### PR TITLE
Show added presences by default

### DIFF
--- a/src/pages/store/index.vue
+++ b/src/pages/store/index.vue
@@ -322,7 +322,7 @@
 				addedPresences: [],
 				nsfw: false,
 				mostUsed: true,
-				showAdded: false,
+				showAdded: true,
 				filterLiked: false,
 				presenceSearch: "",
 				presencesPerPage: 12,


### PR DESCRIPTION
It makes much more sense to have this, also saves us the extra step in tickets where people are like 'I added a presence and it vanished' or 'x presence doesn't show on the store' (because it may already be added and they are unaware or want to view the description)