### PR TITLE
fix(homepage): hide rare badge

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -71,11 +71,11 @@
 												.replace('HOUSE_', '')
 												.toLowerCase()}`"
 										></div>
-										<div
+										<!-- <div
 											v-if="flag == 'EARLY_SUPPORTER'"
 											v-tippy="{ content: 'Early Supporter' }"
 											:class="`badge badge_early`"
-										></div>
+										></div> -->
 										<div
 											v-if="flag == 'HYPESQUAD_EVENTS'"
 											v-tippy="{ content: 'HypeSquad Events' }"


### PR DESCRIPTION
Hide the Early Supporter badge, so contributors don't get [dmed](https://discord.com/channels/493130730549805057/607524579874832446/1199472892673523832) by people wanting to buy it off them.
