### PR TITLE
Change default ext version to 2.7.4

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -308,7 +308,7 @@
 				this.extVersion = res.versions.extension;
 				this.users = res.credits;
 			} catch (err) {
-				this.extVersion = "2.2.3";
+				this.extVersion = "2.7.4";
 				this.users = [generateTemplateUser(), generateTemplateUser()];
 			}
 


### PR DESCRIPTION
Update: Updates the hardcoded default extension version in the error handling block to 2.7.4.

This ensures that users who encounter an error retrieving the latest version information will still receive a compatible default version. The change is located in `src\pages\index.vue`.